### PR TITLE
Completed initial load balancer setup

### DIFF
--- a/loadbalancer/src/lbserver.go
+++ b/loadbalancer/src/lbserver.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+  "net/http"
+  "net/url"
+  "encoding/json"
+  "loadbalancer"
+  "io"
+  "log"
+)
+
+func updateIpTables(w http.ResponseWriter, r *http.Request) {
+  // parse the JSON array of IP/ports from the request body
+  type message struct {
+    Ip, Port, Application string
+  }
+
+  var servers []message
+  dec := json.NewDecoder(r.Body)
+  for {
+    if err := dec.Decode(&servers); err == io.EOF {
+      break
+    } else if err != nil {
+      log.Fatal(err)
+    }
+  }
+
+  serverURLs := make([]url.URL, 0)
+  serverPointers := make([]*url.URL, 0)
+
+  for _, element := range servers {
+    server := url.URL{
+      Scheme: "http",
+      Host: element.Ip + ":" + element.Port,
+    }
+    serverURLs = append(serverURLs, server)
+    serverPointers = append(serverPointers, &server)
+  }
+
+  // start the load balancer, passing in the array
+  // this works, but for some reason it causes the above call to
+  // WriteHeader to be ignored
+  loadbalancer.LoadBalance(loadbalancer.RoundRobin, serverPointers)
+  w.WriteHeader(http.StatusOK)
+
+}
+
+
+// listens for a POST request of IPs and ports from the API server
+func main() {
+  http.HandleFunc("/iptables", updateIpTables)
+  http.ListenAndServe(":9000", nil)
+}

--- a/loadbalancer/src/loadbalancer/loadbalancer.go
+++ b/loadbalancer/src/loadbalancer/loadbalancer.go
@@ -33,6 +33,6 @@ func RoundRobin(servers []*url.URL) *httputil.ReverseProxy {
 // and an array of servers which it will pass to the strategy function
 
 func LoadBalance(fn strategy, servers[]*url.URL) {
-  proxy := RoundRobin(servers)
+  proxy := fn(servers)
   http.ListenAndServe(":9090", proxy)
 }

--- a/loadbalancer/src/loadbalancer/loadbalancer.go
+++ b/loadbalancer/src/loadbalancer/loadbalancer.go
@@ -1,0 +1,38 @@
+package loadbalancer
+
+import (
+  "net/http"
+  "net/http/httputil"
+  "net/url"
+)
+
+// TODO
+// implement the other strategy functions
+
+// define a type that all strategy functions will implement
+type strategy func([]*url.URL) *httputil.ReverseProxy
+
+func RoundRobin(servers []*url.URL) *httputil.ReverseProxy {
+  var currServer int = 0
+  director := func(req *http.Request) {
+    server := servers[currServer]
+    req.URL.Scheme = server.Scheme
+    req.URL.Host = server.Host
+    req.URL.Path = server.Path
+
+    currServer++
+    if currServer > len(servers) - 1 {
+      currServer = 0
+    }
+  }
+  return &httputil.ReverseProxy{Director: director}
+}
+
+
+// the LoadBalance function takes a loadbalancing strategy function,
+// and an array of servers which it will pass to the strategy function
+
+func LoadBalance(fn strategy, servers[]*url.URL) {
+  proxy := RoundRobin(servers)
+  http.ListenAndServe(":9090", proxy)
+}


### PR DESCRIPTION
lbserver.go - the API server that will run on the load balancer box. Receives the IP addresses and ports to balance via HTTP POST to /iptables and starts the load balancer process. Runs on port 9000
loadbalancer.go - the load balancer, which is essentially a reverse proxy server. Runs on port 9090
